### PR TITLE
Add links to all functional pages on the Main page

### DIFF
--- a/src/components/MainPage/ActivePages/ActivePages.module.css
+++ b/src/components/MainPage/ActivePages/ActivePages.module.css
@@ -1,0 +1,27 @@
+.links_wrapper {
+  margin: 40px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  color: var(--dark-primary);
+}
+
+.links {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 30px;
+}
+
+.link {
+  all: unset;
+  cursor: pointer;
+  font-size: 1.5rem;
+  transition: 0.25s;
+
+  &:hover {
+    color: var(--primary);
+    transform: scale(1.15);
+  }
+}

--- a/src/components/MainPage/ActivePages/ActivePages.tsx
+++ b/src/components/MainPage/ActivePages/ActivePages.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import * as styles from './ActivePages.module.css';
+
+function ActivePages() {
+  return (
+    <div className={styles.links_wrapper}>
+      <h3>Our active pages</h3>
+      <div className={styles.links}>
+        <NavLink to="/" className={styles.link}>
+          Home
+        </NavLink>
+        <NavLink to="/login" className={styles.link}>
+          Login
+        </NavLink>
+        <NavLink to="/registration" className={styles.link}>
+          Registration
+        </NavLink>
+      </div>
+    </div>
+  );
+}
+
+export default ActivePages;

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import ShopDescription from '../../components/MainPage/ShopDescription/ShopDescription';
 import ShopFeatures from '../../components/MainPage/ShopFeatures/ShopFeatures';
+import ActivePages from '../../components/MainPage/ActivePages/ActivePages';
 
 function MainPage() {
   return (
     <main>
       <ShopDescription />
+      <ActivePages />
       <ShopFeatures />
     </main>
   );


### PR DESCRIPTION
## Proposed Changes

### Description
Added "Active pages" section to the Main page

## Rationale

### Problem
Apparently, header isn't enough according to [Technical Assignment...](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint2/RSS-ECOMM-2_17.md)

### Solution
Added new section to the Main page with all functional links

### Impact
This feature will help us to avoid picky reviewers