### PR TITLE
Fix addresses

### DIFF
--- a/src/components/RegistrationPage/AddressModal/AddressModal.tsx
+++ b/src/components/RegistrationPage/AddressModal/AddressModal.tsx
@@ -27,7 +27,7 @@ function AddressModal({ onClose, addAddress, addressData, testid }: Props) {
     city: addressData?.city ?? '',
     postalCode: addressData?.postalCode ?? '',
   });
-  const [country, setCountry] = useState<CountryType>('US');
+  const [country, setCountry] = useState<CountryType>(addressData?.country ?? 'US');
   const [inputErrors, setInputErrors] = useState<InputErrors>({
     streetName: '',
     city: '',

--- a/src/components/RegistrationPage/Addresses/Addresses.tsx
+++ b/src/components/RegistrationPage/Addresses/Addresses.tsx
@@ -4,19 +4,15 @@ import AddressCard from '../AddressCard/AddressCard';
 import { AddressData } from '../../../types/customer';
 
 type Props = {
-  setEditMode: (index: number) => void;
+  setEditMode: (key: string) => void;
   removeAddress: (key: string) => void;
-  setDefaultAddress: (
-    index: number,
-    checked: boolean,
-    type: 'defaultBillingAddress' | 'defaultShippingAddress'
-  ) => void;
-  setAddressType: (index: number, checked: boolean, type: 'billingAddresses' | 'shippingAddresses') => void;
+  setDefaultAddress: (key: string, checked: boolean, type: 'defaultBillingAddress' | 'defaultShippingAddress') => void;
+  setAddressType: (key: string, checked: boolean, type: 'billingAddresses' | 'shippingAddresses') => void;
   addresses: AddressData[];
-  billing: number[];
-  shipping: number[];
-  defaultBilling?: number;
-  defaultShipping?: number;
+  billing: string[];
+  shipping: string[];
+  defaultBilling?: string;
+  defaultShipping?: string;
   error?: string;
 };
 
@@ -37,18 +33,18 @@ function Addresses({
       <p>Addresses</p>
       {error && <p className={styles.addresses_error}>{error}</p>}
       <div className={styles.addresses}>
-        {addresses.map((address, index) => (
+        {addresses.map((address) => (
           <AddressCard
             key={address.key}
             addressData={address}
-            setEditMode={() => setEditMode(index)}
+            setEditMode={() => setEditMode(address.key)}
             removeAddress={() => removeAddress(address.key)}
-            setDefaultAddress={(checked, type) => setDefaultAddress(index, checked, type)}
-            setAddressType={(checked, type) => setAddressType(index, checked, type)}
-            billing={billing.includes(index)}
-            shipping={shipping.includes(index)}
-            defaultBilling={index === defaultBilling}
-            defaultShipping={index === defaultShipping}
+            setDefaultAddress={(checked, type) => setDefaultAddress(address.key, checked, type)}
+            setAddressType={(checked, type) => setAddressType(address.key, checked, type)}
+            billing={billing.includes(address.key)}
+            shipping={shipping.includes(address.key)}
+            defaultBilling={address.key === defaultBilling}
+            defaultShipping={address.key === defaultShipping}
           />
         ))}
       </div>


### PR DESCRIPTION
## Proposed Changes

### Description
Fixes related to addresses

## Rationale

### Problem
Edit mode used to set country as 'US' no matter what. Addresses logic would break if add and delete some of them since it was based on indexes

### Solution
Country input now takes country from edit address if it passed. Addresses logic switched to keys. They convert to indexes only when passing data to the API.

### Impact
Bugfix, what else to say