### PR TITLE
Implement dual range slider

### DIFF
--- a/src/components/DualRangeSlider/DualRangeSlider.module.css
+++ b/src/components/DualRangeSlider/DualRangeSlider.module.css
@@ -1,0 +1,42 @@
+.dual_slider {
+  display: flex;
+  position: relative;
+  height: 15px;
+  align-items: center;
+}
+
+.min,
+.max {
+  position: absolute;
+  appearance: none;
+  height: 2px;
+  width: 100%;
+  pointer-events: none;
+
+  &::-webkit-slider-thumb {
+    appearance: none;
+    pointer-events: all;
+    width: 15px;
+    height: 15px;
+    background-color: var(--dark-primary);
+    border-radius: 50%;
+    box-shadow: inset 0 0 0 1px var(--primary);
+    cursor: pointer;
+    transition: 0.25s;
+  }
+  &::-webkit-slider-thumb:hover {
+    background-color: var(--primary);
+    box-shadow: inset 0 0 0 1px var(--dark-primary);
+  }
+  &::-webkit-slider-thumb:active {
+    box-shadow: 0 0 9px var(--dark-primary);
+  }
+}
+
+.min {
+  background-color: var(--primary);
+}
+
+.max {
+  background: none;
+}

--- a/src/components/DualRangeSlider/DualRangeSlider.tsx
+++ b/src/components/DualRangeSlider/DualRangeSlider.tsx
@@ -1,0 +1,43 @@
+import React, { ChangeEventHandler } from 'react';
+import * as styles from './DualRangeSlider.module.css';
+
+type Props = {
+  minValue: number;
+  maxValue: number;
+  onChange: (minValue: number, maxValue: number) => void;
+  min?: number;
+  max?: number;
+  gap?: number;
+};
+
+function DualRangeSlider({ minValue, maxValue, onChange, min = 0, max = 100, gap = 1 }: Props) {
+  const minHandler: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const newMinVal = parseInt(e.target.value, 10);
+    if (newMinVal + gap >= maxValue) {
+      if (newMinVal + gap <= max) {
+        onChange(newMinVal, newMinVal + gap);
+      }
+    } else {
+      onChange(newMinVal, maxValue);
+    }
+  };
+  const maxHandler: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const newMaxVal = parseInt(e.target.value, 10);
+    if (newMaxVal - gap <= minValue) {
+      if (newMaxVal - gap >= min) {
+        onChange(newMaxVal - gap, newMaxVal);
+      }
+    } else {
+      onChange(minValue, newMaxVal);
+    }
+  };
+
+  return (
+    <span className={styles.dual_slider}>
+      <input className={styles.min} type="range" value={minValue} min={min} max={max} onChange={minHandler} />
+      <input className={styles.max} type="range" value={maxValue} min={min} max={max} onChange={maxHandler} />
+    </span>
+  );
+}
+
+export default DualRangeSlider;


### PR DESCRIPTION
## Proposed Changes

### Description
Added dual range slider

## Rationale

### Problem
Problem issued [here](https://github.com/HNY-Badger/ecommerce-app/issues/63)

### Solution
Put 2 sliders inside of span and reworked their basic logic to have 2 thumbs. onChange function sets 2 values (Its dual, duh). You also can set min and max values for the sliders and gap between thumbs

### Impact
This component will be used to set price range in the Catalog page