### PR TITLE
Implement Basic Detailed Product Page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/x-icon" href="./deadpixel.svg">
+  <base href="/" />
   <title>Dead Pixel</title>
 </head>
 <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import RegistrationPage from './pages/RegistrationPage/RegistrationPage';
 import NotFoundPage from './pages/NotFoundPage/NotFoundPage';
 import CatalogPage from './pages/CatalogPage/CatalogPage';
 import ProfilePage from './pages/ProfilePage/ProfilePage';
+import DetailedProductPage from './pages/DetailedProductPage/DetailedProductPage';
 
 export default function App() {
   return (
@@ -18,7 +19,7 @@ export default function App() {
           <Route path="catalog" element={<CatalogPage />} />
           <Route path="profile" element={<ProfilePage />} />
           <Route path="registration" element={<RegistrationPage />} />
-          {/* <Route path="product/:id" element={<DetailedProductPage />} /> */}
+          <Route path="product/:id" element={<DetailedProductPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Route>
       </Routes>

--- a/src/components/DetailedProductPage/ImageSlider/ImageSlider.module.css
+++ b/src/components/DetailedProductPage/ImageSlider/ImageSlider.module.css
@@ -1,0 +1,10 @@
+.slider {
+  object-fit: contain;
+  width: clamp(200px, 50vw, 500px);
+}
+
+@media (max-width: 768px) {
+  .slider {
+    width: clamp(200px, 70vw, 500px);
+  }
+}

--- a/src/components/DetailedProductPage/ImageSlider/ImageSlider.tsx
+++ b/src/components/DetailedProductPage/ImageSlider/ImageSlider.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import * as styles from './ImageSlider.module.css';
+
+type Props = {
+  name: string;
+  images: string[];
+};
+
+function ImageSlider({ name, images }: Props) {
+  return <img className={styles.slider} src={images[0]} alt={name} />;
+}
+
+export default ImageSlider;

--- a/src/components/DetailedProductPage/ProductDetails/ProductDetails.module.css
+++ b/src/components/DetailedProductPage/ProductDetails/ProductDetails.module.css
@@ -1,0 +1,55 @@
+.info {
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+  gap: 30px;
+  color: var(--dark-primary);
+}
+
+.heading {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.name {
+  font-size: 2rem;
+}
+
+.prices {
+  font-size: 1.5rem;
+  font-weight: bold;
+  display: flex;
+  gap: 5px;
+}
+
+.discount_price {
+  padding: 10px;
+  color: var(--white);
+  background-color: var(--dark-primary);
+}
+
+.non_discount_price {
+  text-decoration: line-through;
+  font-size: 1.25rem;
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.attributes {
+  padding-left: 18px;
+
+  & span {
+    font-weight: bold;
+  }
+}
+
+@media (max-width: 768px) {
+  .info {
+    padding: 20px 10px;
+  }
+}

--- a/src/components/DetailedProductPage/ProductDetails/ProductDetails.tsx
+++ b/src/components/DetailedProductPage/ProductDetails/ProductDetails.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import * as styles from './ProductDetails.module.css';
+import { Product } from '../../../types/products';
+
+function formatPrice(price: number, currencyCode: string): string {
+  return Intl.NumberFormat('en-US', { style: 'currency', currency: currencyCode }).format(price);
+}
+
+type Props = {
+  product: Product;
+};
+
+function ProductDetails({ product }: Props) {
+  return (
+    <div className={styles.info}>
+      <div className={styles.heading}>
+        <p className={styles.name}>{product.name}</p>
+        <div className={styles.prices}>
+          {product.price.nonDiscountCentValue ? (
+            <>
+              <p className={styles.discount_price}>
+                {formatPrice(product.price.centValue / 100, product.price.currencyCode)}
+              </p>
+              <p className={styles.non_discount_price}>
+                {formatPrice(product.price.nonDiscountCentValue / 100, product.price.currencyCode)}
+              </p>
+            </>
+          ) : (
+            <p>{formatPrice(product.price.centValue / 100, product.price.currencyCode)}</p>
+          )}
+        </div>
+      </div>
+      <div className={styles.details}>
+        <p>{product.description}</p>
+        <ul className={styles.attributes}>
+          {product.attributes.map((attr) => (
+            <li key={attr.name}>
+              <span>{attr.name}: </span>
+              {attr.value}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default ProductDetails;

--- a/src/data/Products/parsers.ts
+++ b/src/data/Products/parsers.ts
@@ -16,7 +16,7 @@ function parseProductResult(result: ProductResult): Product {
     name: result.name['en-US'],
     description: result.description['en-US'],
     attributes: master.attributes,
-    images: master.images,
+    images: master.images.map((img) => img.url),
     price: {
       centValue: usPrice.value.centAmount,
       currencyCode: usPrice.value.currencyCode,
@@ -39,7 +39,7 @@ function parseDetailedProductResult(result: DetailedProductResult): Product {
     name: current.name['en-US'],
     description: current.description['en-US'],
     attributes: master.attributes,
-    images: master.images,
+    images: master.images.map((img) => img.url),
     price: {
       centValue: usPrice.value.centAmount,
       currencyCode: usPrice.value.currencyCode,

--- a/src/pages/DetailedProductPage/DetailedProductPage.module.css
+++ b/src/pages/DetailedProductPage/DetailedProductPage.module.css
@@ -1,0 +1,23 @@
+.center {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.product {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px;
+  gap: 50px;
+}
+
+@media (max-width: 768px) {
+  .product {
+    gap: 10px;
+    justify-content: start;
+    flex-direction: column;
+  }
+}

--- a/src/pages/DetailedProductPage/DetailedProductPage.tsx
+++ b/src/pages/DetailedProductPage/DetailedProductPage.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import * as styles from './DetailedProductPage.module.css';
+import ProductsAPI from '../../api/products';
+import { Product } from '../../types/products';
+import Spinner from '../../components/Spinner/Spinner';
+import NotFoundPage from '../NotFoundPage/NotFoundPage';
+import ProductDetails from '../../components/DetailedProductPage/ProductDetails/ProductDetails';
+import ImageSlider from '../../components/DetailedProductPage/ImageSlider/ImageSlider';
+
+type ProductState = {
+  product: Product | null;
+  loading: boolean;
+  error: boolean;
+};
+
+function DetailedProductPage() {
+  const { id } = useParams();
+  const [productState, setProductState] = useState<ProductState>({ product: null, loading: true, error: false });
+  useEffect(() => {
+    async function fn() {
+      if (id) {
+        try {
+          const resp = await ProductsAPI.getDetailedProduct(id);
+          setProductState((prev) => ({ ...prev, product: resp, loading: false }));
+        } catch (e) {
+          setProductState((prev) => ({
+            ...prev,
+            loading: false,
+            error: true,
+          }));
+        }
+      } else {
+        setProductState((prev) => ({ ...prev, loading: false, error: true }));
+      }
+    }
+    fn();
+  }, []);
+
+  if (productState.loading) {
+    return (
+      <div className={styles.center}>
+        <Spinner width="100px" />
+      </div>
+    );
+  }
+  if (productState.error) {
+    return <NotFoundPage />;
+  }
+  return (
+    <div className={styles.product}>
+      <ImageSlider name={productState.product?.name!} images={productState.product?.images!} />
+      <ProductDetails product={productState.product!} />
+    </div>
+  );
+}
+
+export default DetailedProductPage;

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -110,7 +110,7 @@ export type Product = {
   name: string;
   description: string;
   attributes: ProductAttribute[];
-  images: ProductImage[];
+  images: string[];
   price: {
     centValue: number;
     currencyCode: string;


### PR DESCRIPTION
## Proposed Changes

### Description
Added basic page for reading detailed information about product

## Rationale

### Problem
Problem issued [here](https://github.com/HNY-Badger/ecommerce-app/issues/54)

### Solution
Detailed page fetches product with provided id, if none found - 404 page displayed. Otherwise, all information about product is present: name, price (+ original price if discounted), description, attributes and first image

### Impact
This page will allow customers to read all the details about product