### PR TITLE
Add Basic Profile Page

### DIFF
--- a/src/components/ProfilePage/AddressField.module.css
+++ b/src/components/ProfilePage/AddressField.module.css
@@ -1,0 +1,31 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--light-primary);
+}
+
+.address {
+  font-size: 1.2rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.badge {
+  padding: 5px 10px;
+  border-radius: 5px;
+  background-color: #f0f1f5;
+  color: #545978;
+}
+
+.badge_default {
+  background-color: #e6f5fe;
+  color: #067cc6;
+}

--- a/src/components/ProfilePage/AddressField.tsx
+++ b/src/components/ProfilePage/AddressField.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import * as styles from './AddressField.module.css';
+
+type AddressInfo = {
+  streetName: string;
+  city: string;
+  country: string;
+  postalCode: string;
+  isShipping: boolean;
+  isBilling: boolean;
+  isShippingDefault: boolean;
+  isBillingDefault: boolean;
+};
+
+type Props = {
+  address: AddressInfo;
+};
+
+function AddressField({ address }: Props) {
+  const { streetName, city, country, postalCode, isBilling, isShipping, isShippingDefault, isBillingDefault } = address;
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.address}>{`${streetName}, ${city}, ${country}, ${postalCode}`}</div>
+      <div className={styles.badges}>
+        {isShipping && <span className={styles.badge}>Shipping</span>}
+        {isBilling && <span className={styles.badge}>Billing</span>}
+        {isShippingDefault && <span className={`${styles.badge} ${styles.badge_default}`}>Default&nbsp;Shipping</span>}
+        {isBillingDefault && <span className={`${styles.badge} ${styles.badge_default}`}>Default&nbsp;Billing</span>}
+      </div>
+    </div>
+  );
+}
+
+export default AddressField;

--- a/src/components/ProfilePage/AddressesInfo.tsx
+++ b/src/components/ProfilePage/AddressesInfo.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useAppSelector } from '../../store/hooks/redux';
+import AddressField from './AddressField';
+import ProfileSection from './ProfileSection';
+
+function AddressesInfo() {
+  const { customer } = useAppSelector((state) => state.customerReducer);
+
+  const addresses = customer?.addresses.map((address) => ({
+    ...address,
+    isShipping: customer.shippingAddressIds.includes(address.id),
+    isBilling: customer.billingAddressIds.includes(address.id),
+    isShippingDefault: customer.defaultShippingAddressId === address.id,
+    isBillingDefault: customer.defaultBillingAddressId === address.id,
+  }));
+
+  return (
+    addresses && (
+      <ProfileSection heading="Addresses" buttonCaption="Edit Adresses">
+        {addresses.map((address) => (
+          <AddressField key={address.id} address={address} />
+        ))}
+      </ProfileSection>
+    )
+  );
+}
+
+export default AddressesInfo;

--- a/src/components/ProfilePage/PersonalInfo.tsx
+++ b/src/components/ProfilePage/PersonalInfo.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useAppSelector } from '../../store/hooks/redux';
+import PersonalInfoField from './PersonalInfoField';
+import ProfileSection from './ProfileSection';
+
+function PersonalInfo() {
+  const { customer } = useAppSelector((state) => state.customerReducer);
+
+  return (
+    customer && (
+      <ProfileSection heading="Personal Details" buttonCaption="Edit Personal Details">
+        <PersonalInfoField value={customer.email} name="Email" />
+        <PersonalInfoField value={customer.firstName} name="First name" />
+        <PersonalInfoField value={customer.lastName} name="Last name" />
+        <PersonalInfoField value={new Date(customer.dateOfBirth).toLocaleDateString('en-us')} name="Date of birth" />
+      </ProfileSection>
+    )
+  );
+}
+
+export default PersonalInfo;

--- a/src/components/ProfilePage/PersonalInfoField.module.css
+++ b/src/components/ProfilePage/PersonalInfoField.module.css
@@ -1,0 +1,22 @@
+.wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 1.2rem;
+  width: 100%;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--light-primary);
+}
+
+.name {
+  margin-right: 15px;
+  font-size: 1.1rem;
+  color: var(--dark-primary);
+  white-space: nowrap;
+}
+
+.value {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 70%;
+}

--- a/src/components/ProfilePage/PersonalInfoField.tsx
+++ b/src/components/ProfilePage/PersonalInfoField.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import * as styles from './PersonalInfoField.module.css';
+
+type Props = {
+  value: string;
+  name: string;
+};
+
+function PersonalInfoField({ value, name }: Props) {
+  return (
+    <div className={styles.wrapper}>
+      <span className={styles.name}>{`${name}:`}</span>
+      <span className={styles.value}>{value}</span>
+    </div>
+  );
+}
+
+export default PersonalInfoField;

--- a/src/components/ProfilePage/ProfileSection.module.css
+++ b/src/components/ProfilePage/ProfileSection.module.css
@@ -1,0 +1,14 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 450px;
+  width: 100%;
+}
+
+.wrapper h3 {
+  padding-left: 5px;
+  border-left: 5px solid #004d5b79;
+  color: var(--dark-primary);
+  line-height: 1;
+}

--- a/src/components/ProfilePage/ProfileSection.tsx
+++ b/src/components/ProfilePage/ProfileSection.tsx
@@ -1,0 +1,20 @@
+import React, { PropsWithChildren } from 'react';
+import Button from '../Button/Button';
+import * as styles from './ProfileSection.module.css';
+
+type Props = {
+  heading: string;
+  buttonCaption: string;
+};
+
+function ProfileSection({ heading, buttonCaption, children }: PropsWithChildren<Props>) {
+  return (
+    <div className={styles.wrapper}>
+      <h3>{heading}</h3>
+      {children}
+      <Button>{buttonCaption}</Button>
+    </div>
+  );
+}
+
+export default ProfileSection;

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,7 @@
 :root {
   --dark-primary: #004e5b;
   --primary: #83a9ac;
+  --light-primary: #83a9ac63;
   --light-grey: #f9f9f9;
   --border-grey: #ebe8f4;
   --border-dark: #cac6da;

--- a/src/pages/ProfilePage/ProfilePage.module.css
+++ b/src/pages/ProfilePage/ProfilePage.module.css
@@ -1,0 +1,9 @@
+.profile {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 15px;
+  flex: 1;
+  padding: 0 10px 20px;
+}

--- a/src/pages/ProfilePage/ProfilePage.tsx
+++ b/src/pages/ProfilePage/ProfilePage.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAppSelector } from '../../store/hooks/redux';
+import * as styles from './ProfilePage.module.css';
+import PersonalInfo from '../../components/ProfilePage/PersonalInfo';
+import AddressesInfo from '../../components/ProfilePage/AddressesInfo';
+import ProfileSection from '../../components/ProfilePage/ProfileSection';
 
 function ProfilePage() {
   const navigate = useNavigate();
@@ -12,7 +16,15 @@ function ProfilePage() {
     }
   }, [customer]);
 
-  return <h1>Profile Page</h1>;
+  return (
+    customer && (
+      <div className={styles.profile}>
+        <PersonalInfo />
+        <AddressesInfo />
+        <ProfileSection heading="Password" buttonCaption="Change Password" />
+      </div>
+    )
+  );
 }
 
 export default ProfilePage;


### PR DESCRIPTION
## Proposed Changes

### Description
Added basic profile page with user data.

## Rationale

### Problem
Problem issued [here](https://github.com/HNY-Badger/ecommerce-app/issues/58).

### Solution
The page displays information about the user, divided into three groups: profile, addresses, and password.

### Impact
This page will allow users to view and edit account information.
