### PR TITLE
Fix products with screens error cause

### DIFF
--- a/src/components/CatalogPage/Filters/Filters.tsx
+++ b/src/components/CatalogPage/Filters/Filters.tsx
@@ -33,7 +33,7 @@ function Filters({ attributes, onAttributeCheck, priceRange, priceLimits, onPric
           attributes.map((attr) => (
             <FilterSection key={attr.name} heading={attr.name}>
               {Array.from(attr.values.entries())
-                .sort(([a], [b]) => a.localeCompare(b))
+                .sort(([a], [b]) => a.toString().localeCompare(b.toString()))
                 .map(([key, value]) => (
                   <CheckBox
                     label={key}


### PR DESCRIPTION
## Proposed Changes

### Description
Fixed error, when choosing category with screens

## Rationale

### Problem
Diagonal attribute had number type instead of string, which caused error, since localeCompare is string method

### Solution
Parsing every data to string before comparing

### Impact
Its a bug fix, what else to say...