### PR TITLE
Add pagination

### DIFF
--- a/src/api/products.ts
+++ b/src/api/products.ts
@@ -5,6 +5,7 @@ import {
   CategoryResult,
   DetailedProductResult,
   Product,
+  ProductsData,
   ProductsParams,
   ProductsResponse,
 } from '../types/products';
@@ -28,11 +29,15 @@ class ProductsAPI {
   }
 
   // filter should be built with data/Products/builder
-  public static async getProducts(params?: ProductsParams): Promise<Product[]> {
+  public static async getProducts(params?: ProductsParams): Promise<ProductsData> {
     const resp = await api.get<ProductsResponse>(`/${process.env.CTP_PROJECT_KEY}/product-projections/search`, {
       params,
     });
-    return resp.data.results.map((result) => parseProductResult(result));
+    const data: ProductsData = {
+      total: resp.data.total,
+      products: resp.data.results.map((result) => parseProductResult(result)),
+    };
+    return data;
   }
 
   public static async getDetailedProduct(id: string): Promise<Product> {

--- a/src/components/CatalogPage/Pagination/Pagination.module.css
+++ b/src/components/CatalogPage/Pagination/Pagination.module.css
@@ -1,0 +1,24 @@
+.pages {
+  display: flex;
+  justify-content: center;
+  gap: 5px;
+  margin: 10px 0;
+}
+
+.page {
+  flex-basis: 100%;
+  all: unset;
+  cursor: pointer;
+  padding: 5px 10px;
+  border: 1px solid var(--dark-primary);
+  transition: 0.25s;
+
+  &:hover {
+    background-color: var(--primary);
+  }
+}
+
+.page.active {
+  color: white;
+  background-color: var(--dark-primary);
+}

--- a/src/components/CatalogPage/Pagination/Pagination.tsx
+++ b/src/components/CatalogPage/Pagination/Pagination.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import * as styles from './Pagination.module.css';
+
+type Props = {
+  currentPage: number;
+  onPageChange: (page: number) => void;
+  totalPages: number;
+};
+
+function Pagination({ currentPage, onPageChange, totalPages }: Props) {
+  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  return (
+    <div className={styles.pages}>
+      {pages.map((page, index) => (
+        <button
+          type="button"
+          className={`${styles.page} ${index === currentPage ? styles.active : ''}`}
+          onClick={() => onPageChange(index)}
+          key={page}
+        >
+          {page}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default Pagination;

--- a/src/components/CatalogPage/Products/Products.module.css
+++ b/src/components/CatalogPage/Products/Products.module.css
@@ -6,6 +6,7 @@
 }
 
 .products {
+  flex: 1;
   padding: 20px;
   display: flex;
   flex-wrap: wrap;

--- a/src/components/CatalogPage/Products/Products.module.css
+++ b/src/components/CatalogPage/Products/Products.module.css
@@ -1,10 +1,3 @@
-.spinner_wrapper {
-  flex: 1;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
 .products {
   flex: 1;
   padding: 20px;

--- a/src/components/CatalogPage/Products/Products.tsx
+++ b/src/components/CatalogPage/Products/Products.tsx
@@ -5,7 +5,10 @@ import { useAppSelector } from '../../../store/hooks/redux';
 import Spinner from '../../Spinner/Spinner';
 
 function Products() {
-  const { products, loading } = useAppSelector((state) => state.productsReducer);
+  const {
+    data: { products },
+    loading,
+  } = useAppSelector((state) => state.productsReducer);
 
   return loading ? (
     <div className={styles.spinner_wrapper}>

--- a/src/components/CatalogPage/Products/Products.tsx
+++ b/src/components/CatalogPage/Products/Products.tsx
@@ -2,19 +2,13 @@ import React from 'react';
 import * as styles from './Products.module.css';
 import ProductCard from '../ProductCard/ProductCard';
 import { useAppSelector } from '../../../store/hooks/redux';
-import Spinner from '../../Spinner/Spinner';
 
 function Products() {
   const {
     data: { products },
-    loading,
   } = useAppSelector((state) => state.productsReducer);
 
-  return loading ? (
-    <div className={styles.spinner_wrapper}>
-      <Spinner width="200px" />
-    </div>
-  ) : (
+  return (
     <div className={styles.products}>
       {products.map((product) => (
         <ProductCard

--- a/src/components/DetailedProductPage/EnlargedImage/EnlargedImage.module.css
+++ b/src/components/DetailedProductPage/EnlargedImage/EnlargedImage.module.css
@@ -9,6 +9,7 @@
 
   z-index: 2;
   background-color: var(--modal-backdrop);
+  backdrop-filter: blur(5px);
 }
 
 .close_btn {

--- a/src/pages/CatalogPage/CatalogPage.module.css
+++ b/src/pages/CatalogPage/CatalogPage.module.css
@@ -32,6 +32,13 @@
   padding: 0 40px;
 }
 
+.spinner_wrapper {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 @media (max-width: 1000px) {
   .content {
     flex-direction: column;

--- a/src/pages/CatalogPage/CatalogPage.tsx
+++ b/src/pages/CatalogPage/CatalogPage.tsx
@@ -14,10 +14,13 @@ import Sort from '../../components/CatalogPage/Sort/Sort';
 import { BreadcrumbLink } from '../../types/breadcrumb';
 import Filters from '../../components/CatalogPage/Filters/Filters';
 import productsToFilterData from '../../data/Filters/productsToFilterData';
+import Pagination from '../../components/CatalogPage/Pagination/Pagination';
+
+const productsOnPage = 10;
 
 function CatalogPage() {
   const dispatch = useAppDispatch();
-  const products = useAppSelector((state) => state.productsReducer);
+  const productsState = useAppSelector((state) => state.productsReducer);
 
   const { id } = useParams();
   const [searchParams] = useSearchParams();
@@ -29,6 +32,8 @@ function CatalogPage() {
   const [priceRange, setPriceRange] = useState<[number, number] | undefined>();
   const [, setPriceTimer] = useState<NodeJS.Timeout>();
   const [priceLimit, setPriceLimit] = useState<[number, number] | undefined>();
+
+  const [page, setPage] = useState<number>(0);
 
   const fetchHandler = () => {
     const params: ProductsParams = {};
@@ -58,12 +63,19 @@ function CatalogPage() {
       });
     }
     params.filter = filter;
+    params.limit = productsOnPage;
+    params.offset = productsOnPage * page;
     dispatch(fetchProducts(params));
   };
 
   useEffect(() => {
     fetchHandler();
-  }, [sortType, searchParams.get('search'), id, attributes]);
+  }, [sortType, page]);
+
+  useEffect(() => {
+    setPage(0);
+    fetchHandler();
+  }, [searchParams.get('search'), attributes, id]);
 
   const priceHandler = (min: number, max: number) => {
     if (
@@ -75,7 +87,10 @@ function CatalogPage() {
       min < max
     ) {
       setPriceRange([min, max]);
-      const timeout = setTimeout(() => fetchHandler(), 1000);
+      const timeout = setTimeout(() => {
+        setPage(0);
+        fetchHandler();
+      }, 1000);
       setPriceTimer((prev) => {
         clearTimeout(prev);
         return timeout;
@@ -102,19 +117,19 @@ function CatalogPage() {
   // Update attributes if they're undefined
   useEffect(() => {
     if (
-      !products.loading &&
-      products.error.length === 0 &&
+      !productsState.loading &&
+      productsState.error.length === 0 &&
       attributes === undefined &&
       priceRange === undefined &&
       priceLimit === undefined
     ) {
-      const { attributes: attrs, minCentPrice, maxCentPrice } = productsToFilterData(products.products);
+      const { attributes: attrs, minCentPrice, maxCentPrice } = productsToFilterData(productsState.data.products);
       setAttributes(attrs);
       const limits: [number, number] = [minCentPrice / 100, maxCentPrice / 100];
       setPriceLimit(limits);
       setPriceRange(limits);
     }
-  }, [products]);
+  }, [productsState]);
 
   // Reset and update attributes only if search query or category changes
   useEffect(() => {
@@ -143,6 +158,10 @@ function CatalogPage() {
       ProductsAPI.getCategories().then((ctgrs) => setCategories(ctgrs));
     }
   }, [id]);
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [page]);
 
   const sortHandler: ChangeEventHandler<HTMLSelectElement> = (e) => {
     const { value } = e.target;
@@ -190,6 +209,11 @@ function CatalogPage() {
             <Sort value={sortType} onChange={sortHandler} />
           </div>
           <Products />
+          <Pagination
+            currentPage={page}
+            onPageChange={(clickedPage) => setPage(clickedPage)}
+            totalPages={Math.ceil(productsState.data.total / productsOnPage)}
+          />
         </div>
       </div>
     </div>

--- a/src/pages/CatalogPage/CatalogPage.tsx
+++ b/src/pages/CatalogPage/CatalogPage.tsx
@@ -15,6 +15,7 @@ import { BreadcrumbLink } from '../../types/breadcrumb';
 import Filters from '../../components/CatalogPage/Filters/Filters';
 import productsToFilterData from '../../data/Filters/productsToFilterData';
 import Pagination from '../../components/CatalogPage/Pagination/Pagination';
+import Spinner from '../../components/Spinner/Spinner';
 
 const productsOnPage = 10;
 
@@ -208,12 +209,20 @@ function CatalogPage() {
             <Search />
             <Sort value={sortType} onChange={sortHandler} />
           </div>
-          <Products />
-          <Pagination
-            currentPage={page}
-            onPageChange={(clickedPage) => setPage(clickedPage)}
-            totalPages={Math.ceil(productsState.data.total / productsOnPage)}
-          />
+          {productsState.loading ? (
+            <div className={styles.spinner_wrapper}>
+              <Spinner width="200px" />
+            </div>
+          ) : (
+            <>
+              <Products />
+              <Pagination
+                currentPage={page}
+                onPageChange={(clickedPage) => setPage(clickedPage)}
+                totalPages={Math.ceil(productsState.data.total / productsOnPage)}
+              />
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/store/async/ProductsThunk.ts
+++ b/src/store/async/ProductsThunk.ts
@@ -1,10 +1,10 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 import { AxiosError } from 'axios';
-import { Product, ProductsParams } from '../../types/products';
+import { ProductsData, ProductsParams } from '../../types/products';
 import ProductsAPI from '../../api/products';
 import { APIErrorResponse } from '../../types/api';
 
-const fetchProducts = createAsyncThunk<Product[] | undefined, ProductsParams, { rejectValue: string | undefined }>(
+const fetchProducts = createAsyncThunk<ProductsData | undefined, ProductsParams, { rejectValue: string | undefined }>(
   'products/fetchProducts',
   async (params: ProductsParams, thunkAPI) => {
     try {

--- a/src/store/reducers/ProductsSlice.ts
+++ b/src/store/reducers/ProductsSlice.ts
@@ -1,11 +1,11 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { Product } from '../../types/products';
+import { ProductsData } from '../../types/products';
 import fetchProducts from '../async/ProductsThunk';
 
-type ProductsState = { products: Product[]; loading: boolean; error: string };
+type ProductsState = { data: ProductsData; loading: boolean; error: string };
 
 const initialState: ProductsState = {
-  products: [],
+  data: { total: 0, products: [] },
   loading: true,
   error: '',
 };
@@ -18,7 +18,7 @@ export const productsSlice = createSlice({
     builder
       .addCase(fetchProducts.fulfilled, (state, action) => {
         const newState = { ...state };
-        newState.products = action.payload ? action.payload : [];
+        newState.data = action.payload ? action.payload : { total: 0, products: [] };
         newState.loading = false;
         newState.error = '';
         return newState;

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -1,4 +1,5 @@
 type Response<T> = {
+  total: number;
   count: number;
   limit: number;
   offset: number;
@@ -122,6 +123,11 @@ export type Product = {
     currencyCode: string;
     nonDiscountCentValue?: number;
   };
+};
+
+export type ProductsData = {
+  total: number;
+  products: Product[];
 };
 
 export type Attribute = {


### PR DESCRIPTION
## Proposed Changes

### Description
Added pagination for catalog page

## Rationale

### Problem
Our customers need a way to see all our products. Also, its issued [here](https://github.com/HNY-Badger/ecommerce-app/issues/82)

### Solution
Added pagination component which creates several buttons based on number of pages and re-fetches products based on offset

### Impact
This feature will allow our customers to go through pages and see all of our products

## Additional Notes
- Added `total` field to products response
- Renamed some variables
- Added backdrop blur filter