### PR TITLE
Improve pagination

### DIFF
--- a/src/components/CatalogPage/Pagination/Pagination.module.css
+++ b/src/components/CatalogPage/Pagination/Pagination.module.css
@@ -1,6 +1,8 @@
 .pages {
   display: flex;
   justify-content: center;
+  align-items: center;
+  color: var(--dark-primary);
   gap: 5px;
   margin: 10px 0;
 }

--- a/src/components/CatalogPage/Pagination/Pagination.tsx
+++ b/src/components/CatalogPage/Pagination/Pagination.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FaAngleDoubleLeft, FaAngleDoubleRight } from 'react-icons/fa';
 import * as styles from './Pagination.module.css';
 
 type Props = {
@@ -8,20 +9,58 @@ type Props = {
 };
 
 function Pagination({ currentPage, onPageChange, totalPages }: Props) {
-  const pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+  let pages = Array.from({ length: totalPages }, (_, i) => i + 1);
+  if (totalPages > 7) {
+    const minOffset = currentPage - 2;
+    const min = minOffset < 0 ? 0 : minOffset;
+    const maxOffset = currentPage + 3;
+    const max = maxOffset > totalPages - 1 ? totalPages : maxOffset;
+    pages = pages.slice(min, max);
+  }
 
   return (
     <div className={styles.pages}>
-      {pages.map((page, index) => (
-        <button
-          type="button"
-          className={`${styles.page} ${index === currentPage ? styles.active : ''}`}
-          onClick={() => onPageChange(index)}
-          key={page}
-        >
-          {page}
-        </button>
-      ))}
+      {totalPages > 7 ? (
+        <>
+          {pages[0] !== 1 && (
+            <>
+              <button type="button" className={`${styles.page}`} onClick={() => onPageChange(0)}>
+                1
+              </button>
+              <FaAngleDoubleLeft />
+            </>
+          )}
+          {pages.map((page) => (
+            <button
+              type="button"
+              className={`${styles.page} ${page - 1 === currentPage ? styles.active : ''}`}
+              onClick={() => onPageChange(page - 1)}
+              key={page}
+            >
+              {page}
+            </button>
+          ))}
+          {pages[pages.length - 1] !== totalPages && (
+            <>
+              <FaAngleDoubleRight />
+              <button type="button" className={`${styles.page}`} onClick={() => onPageChange(totalPages - 1)}>
+                {totalPages}
+              </button>
+            </>
+          )}
+        </>
+      ) : (
+        pages.map((page) => (
+          <button
+            type="button"
+            className={`${styles.page} ${page - 1 === currentPage ? styles.active : ''}`}
+            onClick={() => onPageChange(page - 1)}
+            key={page}
+          >
+            {page}
+          </button>
+        ))
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Proposed Changes

### Description
Pagination can handle huge amount of pages

## Rationale

### Problem
Previous version of pagination was simply showing every page, so in case of big amount of pages it would look strange

### Solution
If there is more than 7 pages, two margin pages (start and end) are displayed, and nearest 2 pages around current page are shown

### Impact
This improvement will allow us to add more products, because there will be no problems with pagination