### PR TITLE
Fix promocode calculation

### DIFF
--- a/src/pageComponents/BasketPage/BasketItem/BasketItem.module.css
+++ b/src/pageComponents/BasketPage/BasketItem/BasketItem.module.css
@@ -56,6 +56,11 @@
   font-size: 1.5rem;
 }
 
+.total_original {
+  font-size: 1rem;
+  text-decoration: line-through;
+}
+
 .remove {
   all: unset;
   cursor: pointer;

--- a/src/pageComponents/BasketPage/BasketItem/BasketItem.tsx
+++ b/src/pageComponents/BasketPage/BasketItem/BasketItem.tsx
@@ -11,6 +11,11 @@ type Props = {
   item: LineItem;
 };
 
+function originalTotalCentPrice(item: LineItem): number {
+  const price = item.price.discounted?.value.centAmount ?? item.price.value.centAmount;
+  return price * item.quantity;
+}
+
 function BasketItem({ item }: Props) {
   const dispatch = useAppDispatch();
   const { data: cart } = useAppSelector((state) => state.cartReducer);
@@ -69,6 +74,11 @@ function BasketItem({ item }: Props) {
             )}
           </div>
           <Counter value={item.quantity} onChange={quantityHandler} className={styles.counter} />
+          {originalTotalCentPrice(item) !== item.totalPrice.centAmount && (
+            <p className={styles.total_original}>
+              {formatPrice(originalTotalCentPrice(item) / 100, item.totalPrice.currencyCode)}
+            </p>
+          )}
           <p className={styles.total}>{formatPrice(item.totalPrice.centAmount / 100, item.totalPrice.currencyCode)}</p>
         </div>
       </div>

--- a/src/pageComponents/BasketPage/BasketItems/BasketItems.tsx
+++ b/src/pageComponents/BasketPage/BasketItems/BasketItems.tsx
@@ -4,7 +4,7 @@ import { LineItem } from '../../../types/cart';
 import BasketItem from '../BasketItem/BasketItem';
 
 type Props = {
-  items?: LineItem[];
+  items: LineItem[];
 };
 
 function BasketItems({ items }: Props) {

--- a/src/pageComponents/DetailedProductPage/ProductDetails/ProductDetails.tsx
+++ b/src/pageComponents/DetailedProductPage/ProductDetails/ProductDetails.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import * as styles from './ProductDetails.module.css';
 import { Product } from '../../../types/products';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks/redux';
-import { createFirstCart, refreshCart, updateCart } from '../../../store/async/CartThunk';
+import { createFirstCart, updateCart } from '../../../store/async/CartThunk';
 import Button from '../../../components/Button/Button';
 import Counter from '../../../components/Counter/Counter';
 

--- a/src/pageComponents/MainPage/ActivePages/ActivePages.tsx
+++ b/src/pageComponents/MainPage/ActivePages/ActivePages.tsx
@@ -25,6 +25,9 @@ function ActivePages() {
         <NavLink to="profile" className={styles.link}>
           Profile
         </NavLink>
+        <NavLink to="basket" className={styles.link}>
+          Cart
+        </NavLink>
       </div>
     </div>
   );

--- a/src/pageComponents/MainPage/Promocodes/Promocodes.module.css
+++ b/src/pageComponents/MainPage/Promocodes/Promocodes.module.css
@@ -25,6 +25,7 @@
 
 .code {
   all: unset;
+  position: relative;
   cursor: pointer;
   padding: 5px;
   color: var(--dark-primary);
@@ -36,4 +37,23 @@
     color: var(--primary);
     border-color: var(--primary);
   }
+}
+
+.code .tooltip {
+  visibility: hidden;
+  box-sizing: border-box;
+  background-color: black;
+  color: var(--white);
+  text-align: center;
+  padding: 5px;
+
+  position: absolute;
+  width: 100%;
+  top: 100%;
+  left: 0;
+  z-index: 1;
+}
+
+.code:hover .tooltip {
+  visibility: visible;
 }

--- a/src/pageComponents/MainPage/Promocodes/Promocodes.tsx
+++ b/src/pageComponents/MainPage/Promocodes/Promocodes.tsx
@@ -28,7 +28,12 @@ function Promocodes() {
           {error.length === 0 && codes != null ? (
             codes.map((code) => (
               <button type="button" onClick={() => codeClickHandler(code.code)} key={code.id} className={styles.code}>
-                {code.code}
+                <div>
+                  <p>{code.code}</p>
+                  {code.description['en-US'].length > 0 && (
+                    <span className={styles.tooltip}>{code.description['en-US']}</span>
+                  )}
+                </div>
               </button>
             ))
           ) : (

--- a/src/pages/BasketPage/BasketPage.module.css
+++ b/src/pages/BasketPage/BasketPage.module.css
@@ -2,7 +2,7 @@
   flex: 1;
   align-self: center;
   display: flex;
-  padding: 10px 20px;
+  padding: 10px 5px;
   max-width: 500px;
 }
 

--- a/src/pages/BasketPage/BasketPage.tsx
+++ b/src/pages/BasketPage/BasketPage.tsx
@@ -9,6 +9,15 @@ import EmptyBasketPage from './EmptyBasketPage';
 import BasketPromocodes from '../../pageComponents/BasketPage/BasketPromocodes/BasketPromocodes';
 import Spinner from '../../components/Spinner/Spinner';
 import ClearBasketModal from '../../pageComponents/BasketPage/ClearBasketModal/ClearBasketModal';
+import { LineItem } from '../../types/cart';
+
+function itemsTotalCentPrice(items: LineItem[]): number {
+  let centTotal = 0;
+  items.forEach((item) => {
+    centTotal += item.variant.prices[0].value.centAmount * item.quantity;
+  });
+  return centTotal;
+}
 
 function BasketPage() {
   const { data: cart, loading } = useAppSelector((state) => state.cartReducer);
@@ -30,26 +39,17 @@ function BasketPage() {
               Clear&nbsp;cart
             </Button>
           </div>
-          <BasketItems items={cart?.lineItems} />
+          <BasketItems items={cart.lineItems} />
           <BasketPromocodes />
-          {cart.discountOnTotalPrice ? (
-            <Subtotal
-              className={styles.subtotal}
-              price={formatPrice(cart.totalPrice.centAmount / 100, cart.totalPrice.currencyCode)}
-              nonDiscountPrice={
-                cart.discountOnTotalPrice &&
-                formatPrice(
-                  (cart.discountOnTotalPrice.discountedAmount.centAmount + cart.totalPrice.centAmount) / 100,
-                  cart.totalPrice.currencyCode
-                )
-              }
-            />
-          ) : (
-            <Subtotal
-              className={styles.subtotal}
-              price={formatPrice(cart.totalPrice.centAmount / 100, cart.totalPrice.currencyCode)}
-            />
-          )}
+          <Subtotal
+            className={styles.subtotal}
+            price={formatPrice(cart.totalPrice.centAmount / 100, cart.totalPrice.currencyCode)}
+            nonDiscountPrice={
+              cart.totalPrice.centAmount !== itemsTotalCentPrice(cart.lineItems)
+                ? formatPrice(itemsTotalCentPrice(cart.lineItems) / 100, cart.totalPrice.currencyCode)
+                : undefined
+            }
+          />
         </div>
       ) : (
         !loading && <EmptyBasketPage />

--- a/src/types/promocode.ts
+++ b/src/types/promocode.ts
@@ -7,6 +7,9 @@ export type Promocode = {
   name: {
     ['en-US']: string;
   };
+  description: {
+    ['en-US']: string;
+  };
 };
 
 export type PromocodeResponse = Response<Promocode[]>;


### PR DESCRIPTION
## Proposed Changes

### Description
Fix cart's price calculation for partial discount

## Rationale

### Problem
Promocodes that applied partial discounts caused original cart's price to disappear due to different response

### Solution
From now on every product's price is calculated individually and compared to price in cart

### Impact
This fix will allow our customers to see original cart's price no matter which promocode they apply

## Additional Notes
- Individual promocode discount for product displays on it
- Added link to basket/cart page for active pages on the Main page
- Promocodes now display their description on hover